### PR TITLE
some package changes

### DIFF
--- a/data/eos/modules/netinstall.yaml
+++ b/data/eos/modules/netinstall.yaml
@@ -499,7 +499,6 @@
     - featherpad
     - gvfs
     - gvfs-mtp
-    - kio-fuse
     - libstatgrab
     - libsysstat
     - lm_sensors

--- a/data/eos/modules/netinstall.yaml
+++ b/data/eos/modules/netinstall.yaml
@@ -327,8 +327,6 @@
     - bluedevil
     - breeze-gtk
     - dolphin
-    - dragon
-    - elisa
     - eos-plasma-sddm-config
     - eos-settings-plasma
     - gwenview
@@ -353,6 +351,7 @@
     - sddm-kcm
     - solid
     - spectacle
+    - vlc
     - xsettingsd
 - name: "GNOME-Desktop"
   description: "GNOME Desktop - designed to put you in control and get things done."


### PR DESCRIPTION
1. remove elisa and dragon to replace with vlc for kde setup:
elisa would bring in vlc anyway.. so installing vlc in replacement for both .. a sit kan handle all media files .
2. removing kio-fuse from lxqt forgotten leftover I bet, pcmanfm is not using such as it is taking gvfs 