### PR TITLE
[packagechooser.conf] Update KDE package list

### DIFF
--- a/data/eos/modules/packagechooser.conf
+++ b/data/eos/modules/packagechooser.conf
@@ -209,15 +209,17 @@ items:
                 - eos-settings-plasma
         packages:
             - ark
-            - audiocd-kio
             - bluedevil
             - breeze-gtk
             - dolphin
             - gwenview
+            - haruna
             - kcalc
             - kate
             - kdeconnect
+            - kdeplasma-addons
             - kde-gtk-config
+            - kgamma5
             - khotkeys
             - kinfocenter
             - kinit
@@ -234,9 +236,7 @@ items:
             - powerdevil
             - print-manager
             - sddm-kcm
-            - solid
             - spectacle
-            - vlc
             - xsettingsd
 
     - id: GNOME-Desktop


### PR DESCRIPTION
Some minor changes to the KDE package list
* Removed `audiocd-kio` since very few people would need that
* Added `kgamma5` because otherwise gamma controls are missing
* Added `kdeplasma-addons` as it frequently requested and confusing to people that it is missing
* Replaced `vlc` with `haruna` - https://haruna.kde.org/
* Removed `solid` since it will come in as a dependency even you deselect it