### PR TITLE
Fix Nvidia DRM kernel module parameter

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -203,7 +203,7 @@ def get_kernel_params(uuid):
         kernel_params.append(f"resume=/dev/mapper/{swap_outer_mappername}")
 
     if "nvidia" in gpu_drivers:
-        kernel_params.append("nvidia-drm.modeset=1")
+        kernel_params.append("nvidia_drm.modeset=1")
 
     return kernel_params
 

--- a/src/modules/grubcfg/main.py
+++ b/src/modules/grubcfg/main.py
@@ -240,7 +240,7 @@ def modify_grub_default(partitions, root_mount_point, distributor):
         kernel_params.append(f"resume=/dev/mapper/{swap_outer_mappername}")
 
     if "nvidia" in gpu_drivers:
-        kernel_params.append("nvidia-drm.modeset=1")
+        kernel_params.append("nvidia_drm.modeset=1")
 
     overwrite = libcalamares.job.configuration.get("overwrite", False)
 


### PR DESCRIPTION
The current kernel module is `nvidia_drm`, not `nvidia-drm`.

See https://download.nvidia.com/XFree86/Linux-x86_64/550.67/README/kms.html.

This change happened in https://download.nvidia.com/XFree86/Linux-x86_64/455.23.04/README/kms.html, not sure how it was missed for 3 years.