### PR TITLE
fix(netinstall.yaml): remove xsane

### DIFF
--- a/data/eos/modules/netinstall.yaml
+++ b/data/eos/modules/netinstall.yaml
@@ -237,7 +237,6 @@
     - hplip
     - python-pyqt5
     - python-reportlab
-    - xsane
     - cups
     - cups-browsed
     - cups-filters


### PR DESCRIPTION
Remove xsane package from "HP printer/scanner support" group. xsane is formerly an optional dependency of hplip but was recently removed from the extra repo (orphaned package).

See also this related issue from the forum: https://forum.endeavouros.com/t/i-am-once-again-in-a-semi-state-of-panic-and-is-in-need-of-your-help/59133