### PR TITLE
[packagechooser] Adds KDE support for additional file formats

### DIFF
--- a/data/eos/modules/packagechooser.conf
+++ b/data/eos/modules/packagechooser.conf
@@ -145,6 +145,7 @@ items:
             - plasma-workspace
             - powerdevil
             - print-manager
+            - qt6-imageformats
             - sddm-kcm
             - spectacle
             - xdg-desktop-portal-kde


### PR DESCRIPTION
Adds support for the file formats: TIFF, MNG, TGA, and WBMP through the package "qt6-imageformats" for KDE.
Qt6-imageformats has a download size of 0.06 MiB and an install size of 0.32 MiB so it should create minimal bloat.