### PR TITLE
add nvidia-inst

### DIFF
--- a/data/eos/modules/netinstall.yaml
+++ b/data/eos/modules/netinstall.yaml
@@ -148,6 +148,7 @@
     - eos-packagelist
     - eos-quickstart
     - eos-rankmirrors
+    - nvidia-inst
     - reflector-simple
     - welcome
 - name: "Recommended applications selection"


### PR DESCRIPTION
added nvidia-inst as it doesn't come preinstalled in a new installation even though there is a nvidia users button in welcome that leads to https://discovery.endeavouros.com/category/nvidia/