### PR TITLE
[shellprocess_fixes_offline.conf] Remove NVIDIA config copy commands …

### DIFF
--- a/data/eos/modules/shellprocess_fixes_offline.conf
+++ b/data/eos/modules/shellprocess_fixes_offline.conf
@@ -12,8 +12,6 @@ dontChroot: true
 verbose: true
 
 script:
- - "cp /etc/calamares/files/nv-modprobe ${ROOT}/usr/lib/modprobe.d/nvidia-utils.conf"
- - "cp /etc/calamares/files/nv-modules-load ${ROOT}/usr/lib/modules-load.d/nvidia-utils.conf"
  - "cp /etc/calamares/files/endeavouros-wallpaper.png ${ROOT}/usr/share/endeavouros/backgrounds/endeavouros-wallpaper.png"
  - "cp -a /etc/calamares/scripts ${ROOT}/etc/calamares/"
 


### PR DESCRIPTION
i am not sure if we need still to copy calamares scripts to the target? 
Wallpaper needs to get replaced, as squashfs image has livesession Wallpaper.